### PR TITLE
Inspect additional columns for non-integer values

### DIFF
--- a/format_tests/format_tests.py
+++ b/format_tests/format_tests.py
@@ -249,8 +249,7 @@ class NonIntegerVotes(RowTest):
                 # There are some rare cases where the value represents a turnout percentage.  We will try and avoid
                 # these rows.
                 percentages = {"%", "pct", "percent"}
-                if self.__candidate_index and (self.__candidate_index < len(row)) \
-                        and any(x in row[self.__candidate_index].lower() for x in percentages):
+                if self.__candidate_index and any(x in row[self.__candidate_index].lower() for x in percentages):
                     continue
 
                 # If the value isn't numeric, skip the test.  This can be due to the row having an inconsistent

--- a/tests/test_format_tests.py
+++ b/tests/test_format_tests.py
@@ -118,8 +118,8 @@ class NonIntegerVotesTest(unittest.TestCase):
         bad_values = ["1.2", "-1.2", "0.01"]
         vote_columns = {"absentee", "early_voting", "election_day", "mail", "provisional", "votes"}
         for column in vote_columns:
-            format_test = format_tests.NonIntegerVotes(["a", "votes ", column, "c"])
             for value in bad_values:
+                format_test = format_tests.NonIntegerVotes(["a", "votes ", column, "c"])
                 format_test.test(["a", 1, value, "c"])
                 self.assertFalse(format_test.passed)
 

--- a/tests/test_format_tests.py
+++ b/tests/test_format_tests.py
@@ -116,10 +116,12 @@ class NonIntegerVotesTest(unittest.TestCase):
             self.assertTrue(format_test.passed)
 
         bad_values = ["1.2", "-1.2", "0.01"]
-        format_test = format_tests.NonIntegerVotes(["a", "votes ", "c"])
-        for value in bad_values:
-            format_test.test(["a", value, "c"])
-            self.assertFalse(format_test.passed)
+        vote_columns = {"absentee", "early_voting", "election_day", "mail", "provisional", "votes"}
+        for column in vote_columns:
+            format_test = format_tests.NonIntegerVotes(["a", "votes ", column, "c"])
+            for value in bad_values:
+                format_test.test(["a", 1, value, "c"])
+                self.assertFalse(format_test.passed)
 
 
 class PrematureLineBreaks(unittest.TestCase):


### PR DESCRIPTION
This modifies the `NonIntegerVotes` class to also inspect the `absentee`, `early_voting`, `election_day`, `mail`, and `provisional` columns for non-integer values.