### PR TITLE
Add support for log files with full failure messages

### DIFF
--- a/format_tests/format_tests.py
+++ b/format_tests/format_tests.py
@@ -46,15 +46,16 @@ class ValueTest(RowTest):
     def passed(self):
         return len(self.__failures) == 0
 
-    def get_failure_message(self, max_examples=10):
+    def get_failure_message(self, max_examples=-1):
         message = f"There are {len(self.__failures)} rows that have entries with {self.description}:\n"
-        count = 1
+        count = 0
         for key, value in self.__failures.items():
-            message += f"\n\tRow {key}: {value}"
-            count += 1
-            if count > max_examples:
+            if (max_examples >= 0) and (count >= max_examples):
                 message += f"\n\t[Truncated to {max_examples} examples]"
-                break
+                return message
+            else:
+                message += f"\n\tRow {key}: {value}"
+                count += 1
 
         return message
 
@@ -186,18 +187,19 @@ class InconsistentNumberOfColumns(RowTest):
     def passed(self):
         return len(self.__failures) == 0
 
-    def get_failure_message(self, max_examples=10):
+    def get_failure_message(self, max_examples=-1):
         message = f"Header has {len(self.__headers)} entries, but there are {len(self.__failures)} " \
                   f"rows with an inconsistent number of columns:\n\n" \
                   f"\tHeaders ({len(self.__headers)} entries): {self.__headers}:"
 
-        count = 1
+        count = 0
         for key, value in self.__failures.items():
-            message += f"\n\tRow {key} ({len(value)} entries): {value}"
-            count += 1
-            if count > max_examples:
+            if (max_examples >= 0) and (count >= max_examples):
                 message += f"\n\t[Truncated to {max_examples} examples]"
-                break
+                return message
+            else:
+                message += f"\n\tRow {key} ({len(value)} entries): {value}"
+                count += 1
 
         return message
 
@@ -229,17 +231,18 @@ class NonIntegerVotes(RowTest):
     def passed(self):
         return len(self.__failures) == 0
 
-    def get_failure_message(self, max_examples=10):
+    def get_failure_message(self, max_examples=-1):
         message = f"There are {len(self.__failures)} rows with votes that aren't integers:\n\n" \
                   f"\tHeaders: {self.__headers}:"
 
-        count = 1
+        count = 0
         for key, value in self.__failures.items():
-            message += f"\n\tRow {key}: {value}"
-            count += 1
-            if count > max_examples:
+            if (max_examples >= 0) and (count >= max_examples):
                 message += f"\n\t[Truncated to {max_examples} examples]"
-                break
+                return message
+            else:
+                message += f"\n\tRow {key}: {value}"
+                count += 1
 
         return message
 

--- a/format_tests/test_format.py
+++ b/format_tests/test_format.py
@@ -1,16 +1,51 @@
 import csv
 from format_tests import format_tests
 import glob
+import logging
 import os
 import unittest
 
 
-class FileFormatTests(unittest.TestCase):
+class TestCase(unittest.TestCase):
+    log_file = None
     root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if TestCase.log_file is None:
+            self.__logger = None
+        else:
+            self.__logger = TestCase.__get_logger(type(self).__name__, TestCase.log_file)
+
+    def _assertTrue(self, result: bool, description: str, short_message: str, full_message: str):
+        if not result:
+            self._log_failure(description, full_message)
+        self.assertTrue(result, short_message)
+
+    def _log_failure(self, description: str, message: str):
+        if self.__logger is not None:
+            self.__logger.debug("======================================================================")
+            self.__logger.debug(f"FAIL: {description}")
+            self.__logger.debug("----------------------------------------------------------------------")
+            self.__logger.debug(f"{message}\n")
+
+    @staticmethod
+    def __get_logger(name: str, log_file: str) -> logging.Logger:
+        handler = logging.FileHandler(log_file)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        logger = logging.getLogger(name)
+        logger.setLevel(logging.DEBUG)
+        logger.addHandler(handler)
+
+        return logger
+
+
+class FileFormatTests(TestCase):
     def test_format(self):
         for csv_file in FileFormatTests.__get_csv_files():
-            short_path = os.path.relpath(csv_file, start=FileFormatTests.root_path)
+            short_path = os.path.relpath(csv_file, start=TestCase.root_path)
 
             tests = set()
 
@@ -46,16 +81,22 @@ class FileFormatTests(unittest.TestCase):
 
                 max_examples = 10
                 passed = True
-                message = f"\n\n{short_path}"
+                short_message = ""
+                full_message = ""
+                is_first_message = True
                 for test in tests:
                     if not test.passed:
                         passed = False
-                        message += f"\n\n* {test.get_failure_message(max_examples)}"
+                        short_message += f"\n\n* {test.get_failure_message(max_examples=max_examples)}"
+                        if not is_first_message:
+                            full_message += "\n\n"
+                        full_message += f"* {test.get_failure_message()}"
+                        is_first_message = False
 
-                self.assertTrue(passed, message)
+                self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
 
     @staticmethod
     def __get_csv_files():
-        for file in glob.glob(os.path.join(FileFormatTests.root_path, "[0-9]" * 4, "**", "*"), recursive=True):
+        for file in glob.glob(os.path.join(TestCase.root_path, "[0-9]" * 4, "**", "*"), recursive=True):
             if file.lower().endswith(".csv"):
                 yield file

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,14 +1,18 @@
 import argparse
-from format_tests.test_format import FileFormatTests
+from format_tests.test_format import FileFormatTests, TestCase
 import unittest
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("root_path", type=str, help="the absolute path to the repository containing files to test")
+    parser.add_argument("--log-file", type=str, help="the absolute path to a file that the full failure messages will "
+                                                     "be written to")
     args = parser.parse_args()
 
-    FileFormatTests.root_path = args.root_path
+    TestCase.root_path = args.root_path
+    TestCase.log_file = args.log_file
+
     test_suite = unittest.defaultTestLoader.loadTestsFromTestCase(FileFormatTests)
     test_runner = unittest.TextTestRunner()
     result = test_runner.run(test_suite)


### PR DESCRIPTION
The failures displayed in the console are currently being truncated for easier navigation within the GitHub Actions interface:
```
* There are 10 rows that have entries with leading or trailing whitespace characters:

	Row 44: ['Alpine', 'U.S. House', '4', 'Brynne S. Kennedy ', 'N', 'N', 'Democratic', '473']
	Row 60: ['Amador', 'U.S. House', '4', 'Brynne S. Kennedy ', 'N', 'N', 'Democratic', '8259']
	Row 91: ['Calaveras', 'U.S. House', '4', 'Brynne S. Kennedy ', 'N', 'N', 'Democratic', '10333']
	Row 170: ['El Dorado', 'U.S. House', '4', 'Brynne S. Kennedy ', 'N', 'N', 'Democratic', '51597']
	Row 188: ['Fresno', 'U.S. House', '4', 'Brynne S. Kennedy ', 'N', 'N', 'Democratic', '2048']
	Row 451: ['Madera', 'U.S. House', '4', 'Brynne S. Kennedy ', 'N', 'N', 'Democratic', '5428']
	Row 482: ['Mariposa', 'U.S. House', '4', 'Brynne S. Kennedy ', 'N', 'N', 'Democratic', '4195']
	Row 595: ['Nevada', 'U.S. House', '4', 'Brynne S. Kennedy ', 'N', 'N', 'Democratic', '7508']
	Row 657: ['Placer', 'U.S. House', '4', 'Brynne S. Kennedy ', 'N', 'N', 'Democratic', '92678']
	Row 1211: ['Tuolumne', 'U.S. House', '4', 'Brynne S. Kennedy ', 'N', 'N', 'Democratic', '12212']
	[Truncated to 10 examples]
```

By adding support for writing the full failure messages to a log file, we can create workflow artifacts that one can download to see all the failures. Previously, one would have to clone multiple repositories, modify a parameter, and run the tests locally to see all the failures.