### PR TITLE
Add option to specify maximum number of rows to print

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,15 @@ A collection of tests to validate the format of OpenElections data files.
 
 ## Usage
 ```
-$ python3 run_tests.py <absolute path to data repository>
+usage: run_tests.py [-h] [--log-file LOG_FILE] [--max-examples N] root_path
+
+positional arguments:
+  root_path            the absolute path to the repository containing files to test
+
+optional arguments:
+  -h, --help           show this help message and exit
+  --log-file LOG_FILE  the absolute path to a file that the full failure messages will be written to
+  --max-examples N     the maximum number of failing rows to print to the console. If a negative value is provided, all failures will be printed.
 ```
 The data are expected to be contained in CSV files that reside under
 directories named by the corresponding election years.  For example,

--- a/format_tests/test_format.py
+++ b/format_tests/test_format.py
@@ -8,6 +8,7 @@ import unittest
 
 class TestCase(unittest.TestCase):
     log_file = None
+    max_examples = -1
     root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 
     def __init__(self, *args, **kwargs):
@@ -79,7 +80,6 @@ class FileFormatTests(TestCase):
                             test.current_row = reader.line_num
                             test.test(row)
 
-                max_examples = 10
                 passed = True
                 short_message = ""
                 full_message = ""
@@ -87,7 +87,7 @@ class FileFormatTests(TestCase):
                 for test in tests:
                     if not test.passed:
                         passed = False
-                        short_message += f"\n\n* {test.get_failure_message(max_examples=max_examples)}"
+                        short_message += f"\n\n* {test.get_failure_message(max_examples=TestCase.max_examples)}"
                         if not is_first_message:
                             full_message += "\n\n"
                         full_message += f"* {test.get_failure_message()}"

--- a/run_tests.py
+++ b/run_tests.py
@@ -8,10 +8,14 @@ if __name__ == "__main__":
     parser.add_argument("root_path", type=str, help="the absolute path to the repository containing files to test")
     parser.add_argument("--log-file", type=str, help="the absolute path to a file that the full failure messages will "
                                                      "be written to")
+    parser.add_argument("--max-examples", type=int, default=10, metavar="N",
+                        help="the maximum number of failing rows to print to the console. If a negative value is "
+                             "provided, all failures will be printed.")
     args = parser.parse_args()
 
     TestCase.root_path = args.root_path
     TestCase.log_file = args.log_file
+    TestCase.max_examples = args.max_examples
 
     test_suite = unittest.defaultTestLoader.loadTestsFromTestCase(FileFormatTests)
     test_runner = unittest.TextTestRunner()


### PR DESCRIPTION
This adds an option to specify the maximum number of failing rows to print to the console. This makes it easier to discover issues when running the test locally.

We also took this opportunity to update the example usage in the README.