### PR TITLE
Simplify bookkeeping of row numbers and improve unit tests

### DIFF
--- a/format_tests/format_tests.py
+++ b/format_tests/format_tests.py
@@ -27,9 +27,13 @@ class RowTest(FormatTest):
     def current_row(self) -> int:
         return self.__current_row
 
-    @current_row.setter
-    def current_row(self, value: int):
-        self.__current_row = value
+    def test(self, value):
+        self.__current_row += 1
+        self._test_row(value)
+
+    @abstractmethod
+    def _test_row(self, row: list[str]):
+        pass
 
 
 class ValueTest(RowTest):
@@ -63,7 +67,7 @@ class ValueTest(RowTest):
     def is_bad_value(self, value) -> bool:
         pass
 
-    def test(self, row: list):
+    def _test_row(self, row: list[str]):
         for entry in row:
             if self.is_bad_value(entry):
                 self.__failures[self.current_row] = row
@@ -168,7 +172,7 @@ class EmptyRows(RowTest):
     def get_failure_message(self, max_examples=0):
         return f"Has {self.__empty_row_count} empty rows."
 
-    def test(self, row: list):
+    def _test_row(self, row: list[str]):
         has_content = False
         for entry in row:
             has_content |= bool(EmptyRows.regex.search(entry))
@@ -203,7 +207,7 @@ class InconsistentNumberOfColumns(RowTest):
 
         return message
 
-    def test(self, row: list):
+    def _test_row(self, row: list[str]):
         if len(row) != len(self.__headers):
             self.__failures[self.current_row] = row
 
@@ -246,7 +250,7 @@ class NonIntegerVotes(RowTest):
 
         return message
 
-    def test(self, row: list):
+    def _test_row(self, row: list[str]):
         if len(row) == len(self.__headers):
             for value in (row[i] for i in self.__indices_to_check):
                 # There are some rare cases where the value represents a turnout percentage.  We will try and avoid

--- a/format_tests/test_format.py
+++ b/format_tests/test_format.py
@@ -72,6 +72,7 @@ class FileFormatTests(TestCase):
                     tests.add(format_tests.NonIntegerVotes(headers))
 
                     for test in tests:
+                        test.current_row = reader.line_num
                         test.test(headers)
 
                     row_tests = tests - header_tests

--- a/format_tests/test_format.py
+++ b/format_tests/test_format.py
@@ -72,13 +72,11 @@ class FileFormatTests(TestCase):
                     tests.add(format_tests.NonIntegerVotes(headers))
 
                     for test in tests:
-                        test.current_row = reader.line_num
                         test.test(headers)
 
                     row_tests = tests - header_tests
                     for row in reader:
                         for test in row_tests:
-                            test.current_row = reader.line_num
                             test.test(row)
 
                 passed = True

--- a/tests/test_format_tests.py
+++ b/tests/test_format_tests.py
@@ -82,15 +82,24 @@ class InconsistentNumberOfColumnsTest(unittest.TestCase):
         format_test.test(["d", "e", ""])
         self.assertTrue(format_test.passed)
 
-        format_test = format_tests.InconsistentNumberOfColumns(headers)
-        format_test.test(["d", "e"])
-        format_test.test(["d", "e", ""])
-        self.assertFalse(format_test.passed)
+        rows = [
+            ["d", "e"],
+            ["d", "e", ""],
+            ["d", "e", "f", "g"],
+            ["d", "e", ""],
+        ]
 
         format_test = format_tests.InconsistentNumberOfColumns(headers)
-        format_test.test(["d", "e", "f", "g"])
-        format_test.test(["d", "e", ""])
+        for row in rows:
+            format_test.test(row)
         self.assertFalse(format_test.passed)
+
+        failure_message = format_test.get_failure_message()
+        self.assertRegex(failure_message, "2 rows.*inconsistent number of columns")
+        self.assertRegex(failure_message, f"Row 1.*" + re.escape(f"{rows[0]}"))
+        self.assertNotRegex(failure_message, "Row 2.*")
+        self.assertRegex(failure_message, f"Row 3.*" + re.escape(f"{rows[2]}"))
+        self.assertNotRegex(failure_message, "Row 4.*")
 
 
 class LeadingAndTrailingSpacesTest(unittest.TestCase):

--- a/tests/test_format_tests.py
+++ b/tests/test_format_tests.py
@@ -215,9 +215,13 @@ class UnknownHeadersTest(unittest.TestCase):
         format_test.test(["a", "b", "c"])
         self.assertTrue(format_test.passed)
 
+        bad_header = ["a", "UnkNowN", "c"]
         format_test = format_tests.UnknownHeaders()
-        format_test.test(["a", "UnkNowN", "c"])
+        format_test.test(bad_header)
         self.assertFalse(format_test.passed)
+
+        failure_message = format_test.get_failure_message()
+        self.assertRegex(failure_message, f"Header.*" + re.escape(f"{bad_header}") + ".*unknown entries")
 
 
 class RunTestsTest(unittest.TestCase):

--- a/tests/test_format_tests.py
+++ b/tests/test_format_tests.py
@@ -165,9 +165,15 @@ class NonIntegerVotesTest(unittest.TestCase):
         vote_columns = {"absentee", "early_voting", "election_day", "mail", "provisional", "votes"}
         for column in vote_columns:
             for value in bad_values:
+                bad_row = ["a", 1, value, "c"]
                 format_test = format_tests.NonIntegerVotes(["a", "votes ", column, "c"])
-                format_test.test(["a", 1, value, "c"])
+                format_test.test(["a", 1, 2, "c"])
+                format_test.test(bad_row)
                 self.assertFalse(format_test.passed)
+
+                failure_message = format_test.get_failure_message()
+                self.assertNotRegex(failure_message, "Row 1.*")
+                self.assertRegex(failure_message, f"Row 2.*" + re.escape(f"{bad_row}"))
 
 
 class PrematureLineBreaks(unittest.TestCase):

--- a/tests/test_format_tests.py
+++ b/tests/test_format_tests.py
@@ -59,15 +59,19 @@ class EmptyRowsTest(unittest.TestCase):
         format_test.test(["a", "b", ""])
         self.assertTrue(format_test.passed)
 
-        format_test = format_tests.EmptyRows()
-        format_test.test(["", "", ""])
-        format_test.test(["a", "b", ""])
-        self.assertFalse(format_test.passed)
+        rows = [
+            ["", "", ""],
+            ["a", "b", ""],
+            [" ", "\t", "\n"]
+        ]
 
         format_test = format_tests.EmptyRows()
-        format_test.test([" ", "\t", "\n"])
-        format_test.test(["a", "b", ""])
+        for row in rows:
+            format_test.test(row)
         self.assertFalse(format_test.passed)
+
+        failure_message = format_test.get_failure_message()
+        self.assertRegex(failure_message, "2 empty rows")
 
 
 class InconsistentNumberOfColumnsTest(unittest.TestCase):

--- a/tests/test_format_tests.py
+++ b/tests/test_format_tests.py
@@ -44,13 +44,13 @@ class EmptyHeadersTest(unittest.TestCase):
         format_test.test(["a", "b", "c"])
         self.assertTrue(format_test.passed)
 
+        header = ["a", "", "c"]
         format_test = format_tests.EmptyHeaders()
-        format_test.test(["a", "", "c"])
+        format_test.test(header)
         self.assertFalse(format_test.passed)
 
-        format_test = format_tests.EmptyHeaders()
-        format_test.test(["", "", "c"])
-        self.assertFalse(format_test.passed)
+        failure_message = format_test.get_failure_message()
+        self.assertRegex(failure_message, re.escape(f"{header}") + ".*empty entries")
 
 
 class EmptyRowsTest(unittest.TestCase):

--- a/tests/test_format_tests.py
+++ b/tests/test_format_tests.py
@@ -108,13 +108,26 @@ class LeadingAndTrailingSpacesTest(unittest.TestCase):
         format_test.test(["a", "b", "c"])
         self.assertTrue(format_test.passed)
 
-        good_value = "b"
-        bad_values = [" b", "b ", "\tb", "b\n"]
-        for bad_value in bad_values:
-            format_test = format_tests.LeadingAndTrailingSpaces()
-            format_test.test(["a", bad_value, "c"])
-            format_test.test(["a", good_value, "c"])
-            self.assertFalse(format_test.passed)
+        rows = [
+            ["a", " b", "c"],
+            ["a", "b", "c"],
+            ["a", "b ", "c"],
+            ["a", "\tb", "c"],
+            ["a", "b\n", "c"],
+        ]
+
+        format_test = format_tests.LeadingAndTrailingSpaces()
+        for row in rows:
+            format_test.test(row)
+        self.assertFalse(format_test.passed)
+
+        failure_message = format_test.get_failure_message()
+        self.assertRegex(failure_message, "4 rows.*leading or trailing whitespace")
+        self.assertRegex(failure_message, f"Row 1.*" + re.escape(f"{rows[0]}"))
+        self.assertNotRegex(failure_message, "Row 2.*")
+        self.assertRegex(failure_message, f"Row 3.*" + re.escape(f"{rows[2]}"))
+        self.assertRegex(failure_message, f"Row 4.*" + re.escape(f"{rows[3]}"))
+        self.assertRegex(failure_message, f"Row 5.*" + re.escape(f"{rows[4]}"))
 
 
 class LowercaseHeadersTest(unittest.TestCase):

--- a/tests/test_format_tests.py
+++ b/tests/test_format_tests.py
@@ -182,10 +182,19 @@ class PrematureLineBreaks(unittest.TestCase):
         format_test.test(["a", "b", "c"])
         self.assertTrue(format_test.passed)
 
+        rows = [
+            ["a", "b\nc", "d"],
+            ["a", "b", "c"],
+        ]
+
         format_test = format_tests.PrematureLineBreaks()
-        format_test.test(["a", "b\nc", "d"])
-        format_test.test(["a", "b", "c"])
+        for row in rows:
+            format_test.test(row)
         self.assertFalse(format_test.passed)
+
+        failure_message = format_test.get_failure_message()
+        self.assertRegex(failure_message, f"Row 1.*" + re.escape(f"{rows[0]}"))
+        self.assertNotRegex(failure_message, "Row 2.*")
 
 
 class TabCharacters(unittest.TestCase):

--- a/tests/test_format_tests.py
+++ b/tests/test_format_tests.py
@@ -14,13 +14,28 @@ class ConsecutiveSpacesTest(unittest.TestCase):
         format_test.test(["a", "b", "c"])
         self.assertTrue(format_test.passed)
 
-        good_value = "b"
-        bad_values = ["b  c", "  b", "b  ", "b \t", "b \n"]
-        for bad_value in bad_values:
-            format_test = format_tests.ConsecutiveSpaces()
-            format_test.test(["a", bad_value, "d"])
-            format_test.test(["a", good_value, "d"])
-            self.assertFalse(format_test.passed)
+        rows = [
+            ["a", "b  c", "d"],
+            ["a", "  b", "d"],
+            ["a", "b", "c"],
+            ["a", "b  ", "d"],
+            ["a", "b \t", "d"],
+            ["a", "b \n", "d"],
+        ]
+
+        format_test = format_tests.ConsecutiveSpaces()
+        for row in rows:
+            format_test.test(row)
+        self.assertFalse(format_test.passed)
+
+        failure_message = format_test.get_failure_message()
+        self.assertRegex(failure_message, "5 rows.*consecutive whitespace")
+        self.assertRegex(failure_message, f"Row 1.*" + re.escape(f"{rows[0]}"))
+        self.assertRegex(failure_message, f"Row 2.*" + re.escape(f"{rows[1]}"))
+        self.assertNotRegex(failure_message, "Row 3.*")
+        self.assertRegex(failure_message, f"Row 4.*" + re.escape(f"{rows[3]}"))
+        self.assertRegex(failure_message, f"Row 5.*" + re.escape(f"{rows[4]}"))
+        self.assertRegex(failure_message, f"Row 6.*" + re.escape(f"{rows[5]}"))
 
 
 class EmptyHeadersTest(unittest.TestCase):

--- a/tests/test_format_tests.py
+++ b/tests/test_format_tests.py
@@ -203,10 +203,19 @@ class TabCharacters(unittest.TestCase):
         format_test.test(["a", "b", "c"])
         self.assertTrue(format_test.passed)
 
+        rows = [
+            ["a", "b\tc", "d"],
+            ["a", "b", "c"],
+        ]
+
         format_test = format_tests.TabCharacters()
-        format_test.test(["a", "b\tc", "d"])
-        format_test.test(["a", "b", "c"])
+        for row in rows:
+            format_test.test(row)
         self.assertFalse(format_test.passed)
+
+        failure_message = format_test.get_failure_message()
+        self.assertRegex(failure_message, f"Row 1.*" + re.escape(f"{rows[0]}"))
+        self.assertNotRegex(failure_message, "Row 2.*")
 
 
 class UnknownHeadersTest(unittest.TestCase):

--- a/tests/test_format_tests.py
+++ b/tests/test_format_tests.py
@@ -136,13 +136,13 @@ class LowercaseHeadersTest(unittest.TestCase):
         format_test.test(["a", "b", "c"])
         self.assertTrue(format_test.passed)
 
+        header = ["a", "B", "c"]
         format_test = format_tests.LowercaseHeaders()
-        format_test.test(["a", "B", "c"])
+        format_test.test(header)
         self.assertFalse(format_test.passed)
 
-        format_test = format_tests.LowercaseHeaders()
-        format_test.test(["A", "B", "c"])
-        self.assertFalse(format_test.passed)
+        failure_message = format_test.get_failure_message()
+        self.assertRegex(failure_message, re.escape(f"{header}") + ".*lowercase")
 
 
 class NonIntegerVotesTest(unittest.TestCase):


### PR DESCRIPTION
This internalizes the responsibility of keeping track of the current row number being tested.  Previously, the current row number would have to be explicitly set before testing each row.  This led to a bug where the reported row number for some header rows would be incorrect (`0` instead of `1`).

We also improved the unit tests by verifying that the failing rows are correctly reported in the failure messages.
