### PR TITLE
Add option to group failures by year in console output

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ A collection of tests to validate the format of OpenElections data files.
 
 ## Usage
 ```
-usage: run_tests.py [-h] [--log-file LOG_FILE] [--max-examples N] root_path
+usage: run_tests.py [-h] [--group-failures] [--log-file LOG_FILE] [--max-examples N] root_path
 
 positional arguments:
   root_path            the absolute path to the repository containing files to test
 
 optional arguments:
   -h, --help           show this help message and exit
+  --group-failures     group the failures by year in the console output using the GitHub Actions group and endgroup workflow commands
   --log-file LOG_FILE  the absolute path to a file that the full failure messages will be written to
   --max-examples N     the maximum number of failing rows to print to the console. If a negative value is provided, all failures will be printed.
 ```

--- a/format_tests/test_format.py
+++ b/format_tests/test_format.py
@@ -1,9 +1,33 @@
 import csv
-from format_tests import format_tests
 import glob
 import logging
 import os
 import unittest
+
+from format_tests import format_tests
+
+
+class TestResult(unittest.TextTestResult):
+    # noinspection PyTypeChecker
+    def printErrorList(self, flavour, errors):
+        group_map = {}
+        ungrouped_errors = []
+        for test, error in errors:
+            if "group" in test.params:
+                group = test.params["group"]
+                if group in group_map:
+                    group_map[group].append((test, error))
+                else:
+                    group_map[group] = [(test, error)]
+            else:
+                ungrouped_errors.append((test, error))
+
+        for group in sorted(group_map.keys()):
+            self.stream.write(f"::group::{group}\n")
+            super().printErrorList(flavour, group_map[group])
+            self.stream.write("::endgroup::\n")
+
+        super().printErrorList(flavour, ungrouped_errors)
 
 
 class TestCase(unittest.TestCase):

--- a/format_tests/test_format.py
+++ b/format_tests/test_format.py
@@ -109,7 +109,7 @@ class FileFormatTests(TestCase):
                 short_message = ""
                 full_message = ""
                 is_first_message = True
-                for test in tests:
+                for test in sorted(tests, key=lambda x: type(x).__name__):
                     if not test.passed:
                         passed = False
                         short_message += f"\n\n* {test.get_failure_message(max_examples=TestCase.max_examples)}"

--- a/format_tests/test_format.py
+++ b/format_tests/test_format.py
@@ -2,6 +2,7 @@ import csv
 import glob
 import logging
 import os
+import pathlib
 import unittest
 
 from format_tests import format_tests
@@ -71,6 +72,7 @@ class FileFormatTests(TestCase):
     def test_format(self):
         for csv_file in FileFormatTests.__get_csv_files():
             short_path = os.path.relpath(csv_file, start=TestCase.root_path)
+            year = pathlib.Path(short_path).parts[0]
 
             tests = set()
 
@@ -87,7 +89,7 @@ class FileFormatTests(TestCase):
             tests.add(format_tests.PrematureLineBreaks())
             tests.add(format_tests.TabCharacters())
 
-            with self.subTest(msg=f"{short_path}"):
+            with self.subTest(msg=f"{short_path}", group=year):
                 with open(csv_file, "r") as csv_data:
                     reader = csv.reader(csv_data)
                     headers = next(reader)

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,11 +1,14 @@
 import argparse
-from format_tests.test_format import FileFormatTests, TestCase
 import unittest
 
+from format_tests.test_format import FileFormatTests, TestCase, TestResult
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("root_path", type=str, help="the absolute path to the repository containing files to test")
+    parser.add_argument("--group-failures", action="store_true",
+                        help="group the failures by year in the console output using the GitHub Actions group and "
+                             "endgroup workflow commands")
     parser.add_argument("--log-file", type=str, help="the absolute path to a file that the full failure messages will "
                                                      "be written to")
     parser.add_argument("--max-examples", type=int, default=10, metavar="N",
@@ -17,8 +20,9 @@ if __name__ == "__main__":
     TestCase.log_file = args.log_file
     TestCase.max_examples = args.max_examples
 
+    result_class = TestResult if args.group_failures else None
+    test_runner = unittest.TextTestRunner(resultclass=result_class)
     test_suite = unittest.defaultTestLoader.loadTestsFromTestCase(FileFormatTests)
-    test_runner = unittest.TextTestRunner()
     result = test_runner.run(test_suite)
 
     if result.wasSuccessful():

--- a/tests/test_format_tests.py
+++ b/tests/test_format_tests.py
@@ -294,6 +294,7 @@ class RunTestsTest(unittest.TestCase):
         ["c", "d", "2", "3"],
     ]
     root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+    year = "2020"
 
     @staticmethod
     def create_data(root_path, year, rows):
@@ -307,22 +308,38 @@ class RunTestsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.bad_data_dir = tempfile.TemporaryDirectory()
-        RunTestsTest.create_data(cls.bad_data_dir.name, "2020", cls.bad_rows)
+        RunTestsTest.create_data(cls.bad_data_dir.name, cls.year, cls.bad_rows)
 
         cls.good_data_dir = tempfile.TemporaryDirectory()
-        RunTestsTest.create_data(cls.good_data_dir.name, "2020", cls.good_rows)
+        RunTestsTest.create_data(cls.good_data_dir.name, cls.year, cls.good_rows)
 
     def setUp(self):
         self.log_file = tempfile.NamedTemporaryFile(dir=self.bad_data_dir.name)
 
-    def run_test(self, root_path):
+    def run_test(self, root_path, *args):
         command = ["python", os.path.join(RunTestsTest.root_path, "run_tests.py"),
-                   f"--log-file={self.log_file.name}", root_path]
+                   f"--log-file={self.log_file.name}"]
+        command.extend(args)
+        command.append(root_path)
         completed_process = subprocess.run(command, capture_output=True)
-        return completed_process.returncode
+        return completed_process
+
+    def test_group_failures(self):
+        completed_process = self.run_test(self.bad_data_dir.name)
+        ungrouped_output = completed_process.stderr.decode()
+        self.assertNotRegex(ungrouped_output, "::group::")
+        self.assertNotRegex(ungrouped_output, "::endgroup::")
+
+        ungrouped_lines = ungrouped_output.splitlines()
+        bad_row_indices = [i for i, row in enumerate(ungrouped_lines) if re.search("----------", row)]
+        expected_group_body = "\n".join(ungrouped_lines[:bad_row_indices[-1]])
+
+        completed_process = self.run_test(self.bad_data_dir.name, "--group-failures")
+        grouped_output = completed_process.stderr.decode()
+        self.assertRegex(grouped_output, rf"::group::{self.year}\s*{re.escape(expected_group_body)}\s*::endgroup::")
 
     def test_failure(self):
-        self.assertEqual(1, self.run_test(self.bad_data_dir.name))
+        self.assertEqual(1, self.run_test(self.bad_data_dir.name).returncode)
 
         with open(self.log_file.name, "r") as log_file:
             log_file_contents = "\n".join(log_file.readlines())
@@ -340,4 +357,4 @@ class RunTestsTest(unittest.TestCase):
         self.assertNotRegex(log_file_contents, re.escape(f"{self.bad_rows[-1]}"))
 
     def test_success(self):
-        self.assertEqual(0, self.run_test(self.good_data_dir.name))
+        self.assertEqual(0, self.run_test(self.good_data_dir.name).returncode)


### PR DESCRIPTION
This adds an option to group the failures by year in the console output using the GitHub Actions group and endgroup [workflow commands](https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#grouping-log-lines). Previously, one would have to navigate possibly tens of thousands of lines of output. Now, the results are grouped by year and folded by default:

![image](https://user-images.githubusercontent.com/17345532/140239126-d5bc1db5-fa01-450a-8db3-01fd6cc608ce.png)

This fixes #9.