### PR TITLE
Add test to detect whitespace in headers

### DIFF
--- a/format_tests/format_tests.py
+++ b/format_tests/format_tests.py
@@ -147,6 +147,26 @@ class UnknownHeaders(FormatTest):
         self.__passed = "unknown" not in [x.strip().lower() for x in headers]
 
 
+class WhitespaceInHeaders(FormatTest):
+    regex = re.compile(r"\s")
+
+    def __init__(self):
+        super().__init__()
+        self.__headers = []
+        self.__passed = True
+
+    @property
+    def passed(self):
+        return self.__passed
+
+    def get_failure_message(self, max_examples=0):
+        return f"Header {self.__headers} contains whitespace characters."
+
+    def test(self, headers: list[str]):
+        self.__headers = headers
+        self.__passed = not any(bool(WhitespaceInHeaders.regex.search(x)) for x in self.__headers)
+
+
 class ConsecutiveSpaces(ValueTest):
     regex = re.compile(r"\s{2,}")
 

--- a/format_tests/test_format.py
+++ b/format_tests/test_format.py
@@ -80,6 +80,7 @@ class FileFormatTests(TestCase):
                 format_tests.EmptyHeaders(),
                 format_tests.LowercaseHeaders(),
                 format_tests.UnknownHeaders(),
+                format_tests.WhitespaceInHeaders(),
             }
             tests.update(header_tests)
 

--- a/tests/test_format_tests.py
+++ b/tests/test_format_tests.py
@@ -273,10 +273,40 @@ class UnknownHeadersTest(unittest.TestCase):
         self.assertRegex(failure_message, f"Header.*" + re.escape(f"{bad_header}") + ".*unknown entries")
 
 
+class WhitespaceInHeadersTest(unittest.TestCase):
+    def test_empty(self):
+        format_test = format_tests.WhitespaceInHeaders()
+        self.assertTrue(format_test.passed)
+
+    def test_headers(self):
+        format_test = format_tests.WhitespaceInHeaders()
+        format_test.test(["a", "b", "c"])
+        self.assertTrue(format_test.passed)
+
+        bad_headers = [
+            ["a", "b ", "c"],
+            ["a", " b", "c"],
+            ["a", "b\n", "c"],
+            ["a", "\nb", "c"],
+            ["a", "b\t", "c"],
+            ["a", "\tb", "c"],
+            ["a", "b c", "d"],
+            ["a", "b\nc", "d"],
+            ["a", "b\tc", "d"],
+        ]
+        for bad_header in bad_headers:
+            format_test = format_tests.WhitespaceInHeaders()
+            format_test.test(bad_header)
+            self.assertFalse(format_test.passed)
+
+            failure_message = format_test.get_failure_message()
+            self.assertRegex(failure_message, f"Header.*" + re.escape(f"{bad_header}") + ".*whitespace")
+
+
 class RunTestsTest(unittest.TestCase):
     bad_data_dir = None
     bad_rows = [
-        ["County", "unknown", "absentee", "votes", ""],  # Lowercase, unknown, and empty headers
+        ["County", "unknown", "absentee votes", "votes", ""],  # Lowercase, unknown, whitespace, and empty headers
         ["", "", "", "", ""],  # Empty rows
         ["a", "b  c", "1", "2", "3"],  # Consecutive whitespace
         ["a", "b", "c", "1", "2", "3"],  # Inconsistent number of columns
@@ -346,6 +376,7 @@ class RunTestsTest(unittest.TestCase):
 
         self.assertRegex(log_file_contents, "Header.*" + re.escape(f"{self.bad_rows[0]}") + ".*lowercase")
         self.assertRegex(log_file_contents, "Header.*" + re.escape(f"{self.bad_rows[0]}") + ".*unknown")
+        self.assertRegex(log_file_contents, "Header.*" + re.escape(f"{self.bad_rows[0]}") + ".*whitespace")
         self.assertRegex(log_file_contents, "Header.*" + re.escape(f"{self.bad_rows[0]}") + ".*empty")
         self.assertRegex(log_file_contents, "1 empty rows")
         self.assertRegex(log_file_contents, "1 rows.*consecutive whitespace")


### PR DESCRIPTION
This adds a test to detect the presence of whitespace characters in the column headers.  Headers that consist of multiple words should be separated by underscores (e.g., `election_day` instead of `election day`).